### PR TITLE
change backend to Vulkan

### DIFF
--- a/Engine/Auto/Scripts/editor.lua
+++ b/Engine/Auto/Scripts/editor.lua
@@ -62,7 +62,7 @@ project("Editor")
 
 	if ENABLE_SPDLOG then
 		defines {
-			"SPDLOG_ENABLE", "SPDLOG_NO_EXCEPTIONS", "SPDLOG_USE_STD_FORMAT",
+			"SPDLOG_ENABLE", "SPDLOG_NO_EXCEPTIONS",
 		}
 
 		includedirs {

--- a/Engine/Auto/Scripts/engine.lua
+++ b/Engine/Auto/Scripts/engine.lua
@@ -108,7 +108,7 @@ project("Engine")
 		}
 
 		defines {
-			"SPDLOG_ENABLE", "SPDLOG_NO_EXCEPTIONS", "SPDLOG_USE_STD_FORMAT",
+			"SPDLOG_ENABLE", "SPDLOG_NO_EXCEPTIONS",
 		}
 	end
 

--- a/Engine/BuiltInShaders/shaders/vs_gaussianSplatting.sc
+++ b/Engine/BuiltInShaders/shaders/vs_gaussianSplatting.sc
@@ -42,7 +42,7 @@ void main()
 		mat3 W = transpose((mat3)u_modelView);
 #endif
 		mat3 T = mul(W, mat3(J));
-		mat3 cov = transpose(T) * Vrk * T;
+		mat3 cov = T * Vrk * transpose(T);
 
 		vec2 vCenter = pos2d.xy / pos2d.w;
 		vCenter.y = -vCenter.y;

--- a/Engine/Source/Editor/Main.cpp
+++ b/Engine/Source/Editor/Main.cpp
@@ -9,7 +9,7 @@ int main()
 	pEngine->Init({ .pTitle = "CatDogEditor", .pIconFilePath = "editor_icon.png",
 		.width = 1280, .height = 720, .useFullScreen = false,
 		.language = Language::ChineseSimplied,
-		.backend = GraphicsBackend::OpenGL, .compileAllShaders = false });
+		.backend = GraphicsBackend::Vulkan, .compileAllShaders = false });
 
 	pEngine->Run();
 

--- a/Engine/Source/Runtime/Log/Log.h
+++ b/Engine/Source/Runtime/Log/Log.h
@@ -5,6 +5,7 @@
 #include "Math/Quaternion.hpp"
 
 #include <spdlog/spdlog.h>
+#include <spdlog/fmt/bundled/format.h>
 
 namespace engine
 {
@@ -48,38 +49,38 @@ private:
 #define CD_ASSERT(x, ...) { if(!(x)) { CD_FATAL(...); __debugbreak(); } }
 
 template<>
-struct std::formatter<cd::Vec2f> : std::formatter<std::string>
+struct fmt::formatter<cd::Vec2f> : fmt::formatter<std::string>
 {
-	auto format(const cd::Vec2f& vec, std::format_context& context) const
+	auto format(const cd::Vec2f &vec, format_context &ctx) const -> decltype(ctx.out())
 	{
-		return formatter<string>::format(std::format("vec2:({}, {})", vec.x(), vec.y()), context);
+		return fmt::format_to(ctx.out(), "vec2:({}, {})", vec.x(), vec.y());
 	}
 };
 
 template<>
-struct std::formatter<cd::Vec3f> : std::formatter<std::string>
+struct fmt::formatter<cd::Vec3f> : fmt::formatter<std::string>
 {
-	auto format(const cd::Vec3f& vec, std::format_context& context) const
+	auto format(const cd::Vec3f &vec, format_context &ctx) const -> decltype(ctx.out())
 	{
-		return formatter<string>::format(std::format("vec3:({}, {}, {})", vec.x(), vec.y(), vec.z()), context);
+		return fmt::format_to(ctx.out(), "vec3:({}, {}, {})", vec.x(), vec.y(), vec.z());
 	}
 };
 
 template<>
-struct std::formatter<cd::Vec4f> : std::formatter<std::string>
+struct fmt::formatter<cd::Vec4f> : fmt::formatter<std::string>
 {
-	auto format(const cd::Vec4f& vec, std::format_context& context) const
+	auto format(const cd::Vec4f &vec, format_context &ctx) const -> decltype(ctx.out())
 	{
-		return formatter<string>::format(std::format("vec4:({}, {}, {}, {})", vec.x(), vec.y(), vec.z(), vec.w()), context);
+		return fmt::format_to(ctx.out(), "vec4:({}, {}, {}, {})", vec.x(), vec.y(), vec.z(), vec.w());
 	}
 };
 
 template<>
-struct std::formatter<cd::Quaternion> : std::formatter<std::string>
+struct fmt::formatter<cd::Quaternion> : fmt::formatter<std::string>
 {
-	auto format(const cd::Quaternion& qua, std::format_context& context) const
+	auto format(const cd::Quaternion &qua, format_context &ctx) const -> decltype(ctx.out())
 	{
-		return formatter<string>::format(std::format("Vector = ({}, {}, {}), Scalar = {}", qua.x(), qua.y(), qua.z(), qua.w()), context);
+		return fmt::format_to(ctx.out(), "Vector = ({}, {}, {}), Scalar = {}", qua.x(), qua.y(), qua.z(), qua.w());
 	}
 };
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9bddb712-2f8a-4bc9-8e76-2ef4f22c8736)
Current Gaussian rotation is incorrect with Vulkan backend
This doesn't seem to be caused by the mvp transform, but by the fact that when the Gaussian is built itself, the rotation is a bit different in different coordinate systems

In opengl it is currently rotated correctly.