### PR TITLE
GS Vulkan branch

### DIFF
--- a/Engine/BuiltInShaders/shaders/vs_gaussianSplatting.sc
+++ b/Engine/BuiltInShaders/shaders/vs_gaussianSplatting.sc
@@ -42,7 +42,7 @@ void main()
 		mat3 W = transpose((mat3)u_modelView);
 #endif
 		mat3 T = mul(W, mat3(J));
-		mat3 cov = transpose(T) * Vrk * T;
+		mat3 cov = T * Vrk * transpose(T);
 
 		vec2 vCenter = pos2d.xy / pos2d.w;
 		vCenter.y = -vCenter.y;

--- a/Engine/Source/Editor/Main.cpp
+++ b/Engine/Source/Editor/Main.cpp
@@ -9,7 +9,7 @@ int main()
 	pEngine->Init({ .pTitle = "CatDogEditor", .pIconFilePath = "editor_icon.png",
 		.width = 1280, .height = 720, .useFullScreen = false,
 		.language = Language::ChineseSimplied,
-		.backend = GraphicsBackend::OpenGL, .compileAllShaders = false });
+		.backend = GraphicsBackend::Vulkan, .compileAllShaders = false });
 
 	pEngine->Run();
 


### PR DESCRIPTION
![383435289-9bddb712-2f8a-4bc9-8e76-2ef4f22c8736](https://github.com/user-attachments/assets/e2292721-3223-49cf-a62a-dd2a9dfe66ab)
Current Gaussian rotation is incorrect with Vulkan backend
This doesn't seem to be caused by the mvp transform, but by the fact that when the Gaussian is built itself, the rotation is a bit different in different coordinate systems

In opengl it is currently rotated correctly.